### PR TITLE
Add template-driven uploads and link management

### DIFF
--- a/panel/models.py
+++ b/panel/models.py
@@ -165,6 +165,66 @@ class Job(Base):
     schedule_slot = relationship("ScheduleSlot", back_populates="job", uselist=False)
 
 
+class Template(Base):
+    __tablename__ = "templates"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255), nullable=False, unique=True)
+    slug = Column(String(255), nullable=True, unique=True)
+    type = Column(String(64), nullable=False, default="description")
+    body = Column(Text, nullable=False)
+    platform = Column(String(64), nullable=True)
+    utm_sets = Column(JSONType, nullable=False, default=dict)
+    default_context = Column(JSONType, nullable=False, default=dict)
+    default_tags = Column(JSONType, nullable=False, default=list)
+    topics = Column(JSONType, nullable=False, default=list)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), default=dt.datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=dt.datetime.utcnow,
+        onupdate=dt.datetime.utcnow,
+        nullable=False,
+    )
+
+
+class Link(Base):
+    __tablename__ = "links"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(255), nullable=False)
+    slug = Column(String(128), nullable=False, unique=True)
+    url = Column(String(1024), nullable=False)
+    description = Column(Text, nullable=True)
+    platform = Column(String(64), nullable=True)
+    utm_params = Column(JSONType, nullable=False, default=dict)
+    metadata = Column(JSONType, nullable=False, default=dict)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), default=dt.datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=dt.datetime.utcnow,
+        onupdate=dt.datetime.utcnow,
+        nullable=False,
+    )
+
+
+class TagLibrary(Base):
+    __tablename__ = "tag_library"
+
+    id = Column(Integer, primary_key=True)
+    tag = Column(String(255), nullable=False, unique=True)
+    category = Column(String(255), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), default=dt.datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=dt.datetime.utcnow,
+        onupdate=dt.datetime.utcnow,
+        nullable=False,
+    )
+
+
 class ScheduleSlot(Base):
     __tablename__ = "schedule_slots"
 

--- a/panel/rendering.py
+++ b/panel/rendering.py
@@ -1,0 +1,151 @@
+"""Рендер пользовательских шаблонов с поддержкой Jinja2 и спинтакса."""
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from jinja2 import Environment, StrictUndefined
+
+from models import Link, Template
+
+_SPIN_PATTERN = re.compile(r"\{([^{}]+)\}")
+
+
+@dataclass
+class RenderResult:
+    text: str
+    context: Dict[str, Any]
+
+
+def _apply_spintax(value: str) -> str:
+    """Раскрыть конструкции вида ``{a|b|c}``.
+
+    Функция выполняет многократную замену, пока не останется вариантов.
+    """
+
+    if "{" not in value:
+        return value
+
+    def _replace_once(match: re.Match[str]) -> str:
+        options = [opt.strip() for opt in match.group(1).split("|") if opt.strip()]
+        if not options:
+            return ""
+        return random.choice(options)
+
+    previous = None
+    current = value
+    while previous != current:
+        previous = current
+        current = _SPIN_PATTERN.sub(_replace_once, current)
+    return current
+
+
+class LinkAccessor:
+    """Предоставляет доступ к активным ссылкам через атрибуты."""
+
+    def __init__(self, links: Mapping[str, Mapping[str, Any]]):
+        self._links = links
+
+    def __getattr__(self, name: str) -> str:
+        data = self._links.get(name)
+        if not data:
+            return ""
+        if not data.get("url"):
+            return ""
+        utm = data.get("utm") or {}
+        url = data["url"]
+        if utm:
+            separator = "&" if "?" in url else "?"
+            kv = "&".join(
+                f"{key}={value}" for key, value in utm.items() if key and value
+            )
+            if kv:
+                return f"{url}{separator}{kv}"
+        return url
+
+    def __contains__(self, name: str) -> bool:  # pragma: no cover - поддержка in
+        data = self._links.get(name)
+        return bool(data and data.get("url"))
+
+
+class TemplateRenderer:
+    def __init__(self):
+        self.env = Environment(autoescape=False, undefined=StrictUndefined, trim_blocks=True)
+
+    @staticmethod
+    def _utm_helper(name: str, link_accessor: Optional[LinkAccessor] = None) -> str:
+        if not name:
+            return ""
+        data = link_accessor._links.get(name) if link_accessor else None  # type: ignore[attr-defined]
+        if data:
+            utm = data.get("utm") or {}
+            if utm:
+                return "&".join(
+                    f"{key}={value}" for key, value in utm.items() if key and value
+                )
+        return ""
+
+    def build_context(
+        self,
+        template: Template,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+        links: Optional[Iterable[Link]] = None,
+    ) -> Dict[str, Any]:
+        ctx: Dict[str, Any] = {}
+        ctx.update(template.default_context or {})
+        if context:
+            ctx.update(context)
+        link_map: Dict[str, Dict[str, Any]] = {}
+        for link in links or []:
+            if not link.is_active:
+                continue
+            link_map[link.slug] = {
+                "url": link.url,
+                "utm": link.utm_params or {},
+            }
+        for key, override in (template.utm_sets or {}).items():
+            if not isinstance(override, Mapping):
+                continue
+            entry = link_map.setdefault(key, {"url": "", "utm": {}})
+            utm = dict(entry.get("utm") or {})
+            for k, v in override.items():
+                if not k or v is None:
+                    continue
+                utm[k] = str(v)
+            entry["utm"] = utm
+        accessor = LinkAccessor(link_map)
+        ctx.setdefault("links", accessor)
+        if "utm" not in ctx:
+            ctx["utm"] = lambda name, _accessor=accessor: self._utm_helper(name, _accessor)
+        return ctx
+
+    def render(
+        self,
+        template: Template,
+        *,
+        context: Optional[Mapping[str, Any]] = None,
+        links: Optional[Iterable[Link]] = None,
+        apply_spintax: bool = True,
+    ) -> RenderResult:
+        ctx = self.build_context(template, context=context, links=links)
+        jinja_template = self.env.from_string(template.body)
+        rendered = jinja_template.render(ctx)
+        if apply_spintax:
+            rendered = _apply_spintax(rendered)
+        return RenderResult(text=rendered.strip(), context=ctx)
+
+
+def parse_context(raw: str) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - пользовательский ввод
+        raise ValueError(f"Некорректный JSON контекста: {exc}") from exc
+    if not isinstance(data, MutableMapping):
+        raise ValueError("Контекст должен быть JSON-объектом")
+    return dict(data)

--- a/panel/static/style.css
+++ b/panel/static/style.css
@@ -211,6 +211,10 @@ fieldset {
   gap: 12px;
 }
 
+.tag-fieldset {
+  flex-direction: column;
+}
+
 button {
   background: #2563eb;
   color: #fff;
@@ -225,6 +229,14 @@ button:hover {
   transform: translateY(-1px);
 }
 
+.button-secondary {
+  background: #475569;
+}
+
+.danger {
+  background: #dc2626;
+}
+
 .form-actions {
   margin-top: 12px;
 }
@@ -232,6 +244,12 @@ button:hover {
 .note {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-top: 6px;
 }
 
 .queue-table {
@@ -301,4 +319,65 @@ button:hover {
 .meta {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.stack-form {
+  display: grid;
+  gap: 12px;
+}
+
+.form-row-inline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.inline-form {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.stack-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.template-preview {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 12px;
+  border-radius: 8px;
+  min-height: 60px;
+  white-space: pre-wrap;
+  margin-top: 8px;
+}
+
+.tag-group {
+  display: grid;
+  gap: 8px;
+}
+
+.tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.chip input {
+  accent-color: #2563eb;
+}
+
+.queue-table tr.is-inactive {
+  opacity: 0.6;
 }

--- a/panel/static/templates.js
+++ b/panel/static/templates.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const initPreviewButton = (button) => {
+    button.addEventListener('click', async () => {
+      const form = button.closest('form');
+      const selectSelector = button.dataset.templateSelect || "select[name='template_id']";
+      const contextFieldSelector = button.dataset.contextField;
+      const previewTargetSelector = button.dataset.previewTarget;
+      const select = form ? form.querySelector(selectSelector) : document.querySelector(selectSelector);
+      const contextField = form && contextFieldSelector ? form.querySelector(contextFieldSelector) : document.querySelector(contextFieldSelector || selectSelector.replace('select', 'textarea'));
+      const previewTarget = previewTargetSelector ? document.querySelector(previewTargetSelector) : null;
+      if (!select || !select.value) {
+        alert('Выберите шаблон');
+        return;
+      }
+      const contextValue = contextField ? contextField.value : '';
+      button.disabled = true;
+      if (previewTarget) {
+        previewTarget.textContent = 'Рендеринг...';
+      }
+      try {
+        const response = await fetch('/templates/render', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            template_id: select.value,
+            context: contextValue,
+            apply_spintax: false,
+          }),
+        });
+        const data = await response.json();
+        if (!data.ok) {
+          const message = data.error || 'Ошибка предпросмотра';
+          if (previewTarget) {
+            previewTarget.textContent = message;
+          } else {
+            alert(message);
+          }
+          return;
+        }
+        if (previewTarget) {
+          previewTarget.textContent = data.rendered || '';
+        }
+      } catch (err) {
+        console.error(err);
+        if (previewTarget) {
+          previewTarget.textContent = 'Ошибка связи с сервером';
+        }
+      } finally {
+        button.disabled = false;
+      }
+    });
+  };
+
+  document.querySelectorAll('[data-template-preview-button]').forEach(initPreviewButton);
+
+  const templateSelect = document.querySelector('[data-template-select]');
+  const contextField = document.querySelector('[data-template-context]');
+  if (templateSelect && contextField) {
+    const fillContext = () => {
+      const option = templateSelect.selectedOptions[0];
+      if (!option) {
+        return;
+      }
+      const defaultContext = option.dataset.defaultContext;
+      if (defaultContext && !contextField.value.trim()) {
+        contextField.value = defaultContext;
+      }
+    };
+    templateSelect.addEventListener('change', fillContext);
+    fillContext();
+  }
+});

--- a/panel/templates/index.html
+++ b/panel/templates/index.html
@@ -30,17 +30,46 @@
       <input name="title" placeholder="по умолчанию = имя файла">
     </div>
     <div class="form-row">
-      <label>Description</label>
-      <textarea name="description" rows="4"></textarea>
+      <label for="template_id">Шаблон описания</label>
+      <select name="template_id" id="template_id" required data-template-select>
+        <option value="" disabled selected>Выберите шаблон</option>
+        {% for template in templates %}
+        <option value="{{ template.id }}" data-default-context='{{ template.default_context | tojson if template.default_context else '' }}'>{{ template.name }}</option>
+        {% endfor %}
+      </select>
+      {% if not templates %}
+      <p class="hint">Создайте шаблон в разделе «Шаблоны».</p>
+      {% endif %}
     </div>
     <div class="form-row">
-      <label>Telegram ссылка</label>
-      <input name="tg" placeholder="https://t.me/your_channel">
+      <label for="template_context">Контекст (JSON)</label>
+      <textarea name="template_context" id="template_context" rows="4" placeholder='{"title": "Видео"}' data-template-context></textarea>
+      <button type="button" class="button-secondary" data-template-preview-button data-template-select="#template_id" data-context-field="#template_context" data-preview-target="#template-preview">Предпросмотр</button>
+      <pre id="template-preview" class="template-preview" aria-live="polite"></pre>
     </div>
-    <div class="form-row">
-      <label>Tags (через запятую)</label>
-      <input name="tags" value="youtube,shorts">
-    </div>
+    <fieldset class="form-row tag-fieldset">
+      <legend>Дополнительные теги</legend>
+      <p class="hint">Теги шаблона объединяются с выбранными значениями. Лимит — {{ MAX_TAGS }} тегов.</p>
+      {% if quick_tags %}
+        {% for category, group in quick_tags | groupby('category') %}
+        {% set items = group.list %}
+        <div class="tag-group">
+          <strong>{{ category or 'Без категории' }}</strong>
+          <div class="tag-chips">
+            {% for tag in items %}
+            <label class="chip">
+              <input type="checkbox" name="tag_ids" value="{{ tag.id }}">
+              <span>{{ tag.tag }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <p class="hint">Добавьте быстрые теги в разделе «Шаблоны».</p>
+      {% endif %}
+      <input name="custom_tags" placeholder="Дополнительные теги через запятую">
+    </fieldset>
     <div class="form-row">
       <label>CategoryId</label>
       <input name="categoryId" value="22">
@@ -98,4 +127,5 @@
     <button type="submit">Старт загрузки (всё из очереди)</button>
   </form>
 </section>
+<script src="{{ url_for('static', filename='templates.js') }}" defer></script>
 {% endblock %}

--- a/panel/templates/layout.html
+++ b/panel/templates/layout.html
@@ -45,6 +45,8 @@
     <nav class="sidebar-nav">
       {% if has_role(ROLE_EDITOR) or has_role(ROLE_OWNER) %}
       <a href="{{ url_for('index') }}">Загрузка</a>
+      <a href="{{ url_for('templates_view') }}">Шаблоны</a>
+      <a href="{{ url_for('links_view') }}">Ссылки</a>
       {% endif %}
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('queue_view') }}">Дашборд</a>

--- a/panel/templates/links_manage.html
+++ b/panel/templates/links_manage.html
@@ -1,0 +1,122 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Ссылки и UTM-наборы</h1>
+<p>Активные ссылки доступны в шаблонах через объект <code>links</code> (например, <code>{{ '{{ links.tg }}' }}</code>). Используйте переключатель, чтобы скрыть ненужные каналы.</p>
+<section class="card">
+  <h2>Новая ссылка</h2>
+  <form method="post" action="{{ url_for('links_create') }}" class="stack-form">
+    <div class="form-row">
+      <label>Название</label>
+      <input name="name" required>
+    </div>
+    <div class="form-row">
+      <label>Slug</label>
+      <input name="slug" required placeholder="tg, vk, site">
+    </div>
+    <div class="form-row">
+      <label>URL</label>
+      <input name="url" required placeholder="https://example.com">
+    </div>
+    <div class="form-row">
+      <label>Платформа</label>
+      <input name="platform" placeholder="Telegram">
+    </div>
+    <div class="form-row">
+      <label>Описание</label>
+      <input name="description" placeholder="подпись">
+    </div>
+    <div class="form-row">
+      <label>UTM-параметры (JSON)</label>
+      <textarea name="utm_params" rows="2" placeholder='{"utm_source": "tg"}'></textarea>
+    </div>
+    <div class="form-row">
+      <label>Доп. данные (JSON)</label>
+      <textarea name="metadata" rows="2"></textarea>
+    </div>
+    <div class="form-row form-row-inline">
+      <label><input type="checkbox" name="is_active" checked> Активна</label>
+      <button type="submit">Добавить ссылку</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h2>Все ссылки</h2>
+  {% if links %}
+  <table class="queue-table">
+    <thead>
+      <tr>
+        <th>Название</th>
+        <th>Slug</th>
+        <th>URL</th>
+        <th>Платформа</th>
+        <th>UTM</th>
+        <th>Статус</th>
+        <th>Действия</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for link in links %}
+      <tr class="{% if not link.is_active %}is-inactive{% endif %}">
+        <td>{{ link.name }}</td>
+        <td>{{ link.slug }}</td>
+        <td><small>{{ link.url }}</small></td>
+        <td>{{ link.platform or '—' }}</td>
+        <td><small>{{ link.utm_params | tojson(indent=2) if link.utm_params else '—' }}</small></td>
+        <td>{{ 'Активна' if link.is_active else 'Выключена' }}</td>
+        <td>
+          <form method="post" action="{{ url_for('links_update', link_id=link.id) }}" class="stack-inline">
+            <button type="submit" name="action" value="toggle" class="button-secondary">{% if link.is_active %}Выключить{% else %}Включить{% endif %}</button>
+            <button type="submit" name="action" value="delete" class="danger">Удалить</button>
+          </form>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="7">
+          <details>
+            <summary>Редактировать</summary>
+            <form method="post" action="{{ url_for('links_update', link_id=link.id) }}" class="stack-form">
+              <div class="form-row">
+                <label>Название</label>
+                <input name="name" value="{{ link.name }}" required>
+              </div>
+              <div class="form-row">
+                <label>Slug</label>
+                <input name="slug" value="{{ link.slug }}" required>
+              </div>
+              <div class="form-row">
+                <label>URL</label>
+                <input name="url" value="{{ link.url }}" required>
+              </div>
+              <div class="form-row">
+                <label>Платформа</label>
+                <input name="platform" value="{{ link.platform or '' }}">
+              </div>
+              <div class="form-row">
+                <label>Описание</label>
+                <input name="description" value="{{ link.description or '' }}">
+              </div>
+              <div class="form-row">
+                <label>UTM-параметры (JSON)</label>
+                <textarea name="utm_params" rows="2">{{ link.utm_params | tojson(indent=2) if link.utm_params else '' }}</textarea>
+              </div>
+              <div class="form-row">
+                <label>Доп. данные (JSON)</label>
+                <textarea name="metadata" rows="2">{{ link.metadata | tojson(indent=2) if link.metadata else '' }}</textarea>
+              </div>
+              <div class="form-row form-row-inline">
+                <label><input type="checkbox" name="is_active" value="1" {% if link.is_active %}checked{% endif %}> Активна</label>
+                <button type="submit">Сохранить</button>
+              </div>
+            </form>
+          </details>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>Ссылок пока нет.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/panel/templates/templates_manage.html
+++ b/panel/templates/templates_manage.html
@@ -1,0 +1,149 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Шаблоны описаний</h1>
+<p>Используйте шаблоны, чтобы стандартизировать описания и теги для заданий. Поддерживаются переменные Jinja2 и условия.</p>
+<section class="card">
+  <h2>Новый шаблон</h2>
+  <form method="post" action="{{ url_for('templates_create') }}" class="stack-form">
+    <div class="form-row">
+      <label>Название</label>
+      <input name="name" required>
+    </div>
+    <div class="form-row">
+      <label>Slug</label>
+      <input name="slug" placeholder="опционально">
+    </div>
+    <div class="form-row">
+      <label>Тип</label>
+      <input name="type" value="description">
+    </div>
+    <div class="form-row">
+      <label>Платформа</label>
+      <input name="platform" placeholder="YouTube, VK и т.п.">
+    </div>
+    <div class="form-row">
+      <label>UTM-наборы (JSON)</label>
+      <textarea name="utm_sets" rows="2" placeholder='{"vk": {"utm_source": "vk"}}'></textarea>
+    </div>
+    <div class="form-row">
+      <label>Контекст по умолчанию (JSON)</label>
+      <textarea name="default_context" rows="2" placeholder='{"title": "Видео"}'></textarea>
+    </div>
+    <div class="form-row">
+      <label>Теги по умолчанию</label>
+      <input name="default_tags" placeholder="tag1, tag2">
+    </div>
+    <div class="form-row">
+      <label>Тематики</label>
+      <input name="topics" placeholder="education, travel">
+    </div>
+    <div class="form-row">
+      <label>Тело шаблона</label>
+      <textarea name="body" rows="6" required placeholder="Например: {{ title }}"></textarea>
+    </div>
+    <div class="form-row form-row-inline">
+      <label><input type="checkbox" name="is_active" checked> Активен</label>
+      <button type="submit">Создать</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h2>Список шаблонов</h2>
+  {% if templates %}
+    {% for template in templates %}
+    <form method="post" action="{{ url_for('templates_update', template_id=template.id) }}" class="stack-form template-item" data-template-form>
+      <h3>{{ template.name }}</h3>
+      <div class="form-row">
+        <label>Название</label>
+        <input name="name" value="{{ template.name }}" required>
+      </div>
+      <div class="form-row">
+        <label>Slug</label>
+        <input name="slug" value="{{ template.slug or '' }}">
+      </div>
+      <div class="form-row">
+        <label>Тип</label>
+        <input name="type" value="{{ template.type }}">
+      </div>
+      <div class="form-row">
+        <label>Платформа</label>
+        <input name="platform" value="{{ template.platform or '' }}">
+      </div>
+      <div class="form-row">
+        <label>UTM-наборы (JSON)</label>
+        <textarea name="utm_sets" rows="2">{{ template.utm_sets | tojson(indent=2) if template.utm_sets else '' }}</textarea>
+      </div>
+      <div class="form-row">
+        <label>Контекст по умолчанию (JSON)</label>
+        <textarea name="default_context" rows="2">{{ template.default_context | tojson(indent=2) if template.default_context else '' }}</textarea>
+      </div>
+      <div class="form-row">
+        <label>Теги по умолчанию</label>
+        <input name="default_tags" value="{{ template.default_tags | join(', ') }}">
+      </div>
+      <div class="form-row">
+        <label>Тематики</label>
+        <input name="topics" value="{{ template.topics | join(', ') }}">
+      </div>
+      <div class="form-row">
+        <label>Тело шаблона</label>
+        <textarea name="body" rows="6" required>{{ template.body }}</textarea>
+      </div>
+      <div class="form-row form-row-inline">
+        <label><input type="checkbox" name="is_active" value="1" {% if template.is_active %}checked{% endif %}> Активен</label>
+        <button type="button" class="button-secondary" data-template-preview-button data-template-id="{{ template.id }}" data-context-field="textarea[name='default_context']" data-preview-target="#template-preview-{{ template.id }}">Предпросмотр</button>
+        <button type="submit">Сохранить</button>
+        <button type="submit" name="action" value="delete" class="danger">Удалить</button>
+      </div>
+      <pre class="template-preview" id="template-preview-{{ template.id }}" aria-live="polite"></pre>
+    </form>
+    {% endfor %}
+  {% else %}
+    <p>Шаблонов пока нет.</p>
+  {% endif %}
+</section>
+
+<section class="card">
+  <h2>Библиотека тегов</h2>
+  <form method="post" action="{{ url_for('tags_create') }}" class="form-row-inline">
+    <input name="tag" placeholder="Новый тег" required>
+    <input name="category" placeholder="Категория">
+    <label><input type="checkbox" name="is_active" checked> Активен</label>
+    <button type="submit">Добавить тег</button>
+  </form>
+  {% if tags %}
+  <table class="queue-table">
+    <thead>
+      <tr>
+        <th>Тег</th>
+        <th>Категория</th>
+        <th>Статус</th>
+        <th>Действия</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tag in tags %}
+      <tr>
+        <td>{{ tag.tag }}</td>
+        <td>{{ tag.category or '—' }}</td>
+        <td>{{ 'Активен' if tag.is_active else 'Выключен' }}</td>
+        <td>
+          <form method="post" action="{{ url_for('tags_update', tag_id=tag.id) }}" class="inline-form">
+            <input type="hidden" name="tag" value="{{ tag.tag }}">
+            <input type="hidden" name="category" value="{{ tag.category or '' }}">
+            <input type="hidden" name="is_active" value="{{ 1 if tag.is_active else 0 }}">
+            <button type="submit" name="action" value="toggle" class="button-secondary">{% if tag.is_active %}Отключить{% else %}Включить{% endif %}</button>
+            <button type="submit" name="action" value="delete" class="danger">Удалить</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>Теги не заданы.</p>
+  {% endif %}
+</section>
+<script src="{{ url_for('static', filename='templates.js') }}" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add persistent models for templates, links, and tag library together with a rendering service supporting Jinja2 and spintax
- rework the upload flow to render descriptions via templates, merge tags with validation, and expose CRUD routes plus preview API for templates, links, and tag chips
- refresh the UI with new management screens, template preview tooling, and updated styles/scripts for quick tag selection

## Testing
- python -m compileall panel


------
https://chatgpt.com/codex/tasks/task_e_68e2797117348333bfdd1b6ef98ee8d2