### PR TITLE
Ensure template contexts are stored as JSON-serializable data

### DIFF
--- a/panel/app.py
+++ b/panel/app.py
@@ -3,7 +3,7 @@ import json
 import os
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 from zoneinfo import ZoneInfo
 
 from flask import (
@@ -645,7 +645,7 @@ def upload():
             thumb_path=thumb_path,
             status=status,
             template_id=template.id,
-            template_context=render_result.context,
+            template_context=render_result.serializable_context,
         )
         job.channel = channel
         session.add(job)
@@ -1085,6 +1085,8 @@ def api_jobs_create():
                 template_context = json.loads(template_context)
             except json.JSONDecodeError:
                 template_context = {}
+        if isinstance(template_context, Mapping):
+            template_context = template_renderer.make_serializable_context(template_context)
         category_id = str(payload.get("category_id") or "22")
         status = "scheduled" if publish_at_utc else "queued"
         if publish_at_utc:

--- a/tests/test_template_context_serialization.py
+++ b/tests/test_template_context_serialization.py
@@ -1,0 +1,99 @@
+import io
+import json
+import os
+import tempfile
+from typing import Iterator
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("sqlalchemy")
+
+
+_DB_FD, _DB_PATH = tempfile.mkstemp(prefix="panel-test-", suffix=".db")
+os.close(_DB_FD)
+os.environ["DATABASE_URL"] = f"sqlite:///{_DB_PATH}"
+
+import panel.panel.app as app_module  # noqa: E402  # pylint: disable=wrong-import-position
+from panel.panel.database import SessionLocal  # noqa: E402
+from panel.panel.models import Account, Channel, Job, Link, Template  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _override_upload_dir(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    upload_dir = tmp_path_factory.mktemp("uploads")
+    original_upload_dir = app_module.UPLOAD_DIR
+    app_module.UPLOAD_DIR = str(upload_dir)
+    try:
+        yield
+    finally:
+        app_module.UPLOAD_DIR = original_upload_dir
+
+
+def teardown_module(_module) -> None:  # noqa: D401 - pytest hook
+    if os.path.exists(_DB_PATH):
+        os.remove(_DB_PATH)
+
+
+def test_upload_stores_serializable_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_module.schedule_pending_jobs, "delay", Mock())
+    monkeypatch.setattr(app_module.trigger_ready_jobs, "delay", Mock())
+
+    with SessionLocal() as session:
+        account = Account(name="Test account", timezone="UTC")
+        channel = Channel(name="Main", timezone="UTC", account=account)
+        template = Template(
+            name="Default",
+            body="{{ greeting }} {{ extra }} {{ links.promo }}",
+            default_context={"greeting": "Hello"},
+        )
+        link = Link(
+            name="Promo",
+            slug="promo",
+            url="https://example.com",
+            utm_params={"source": "test"},
+        )
+        session.add_all([account, channel, template, link])
+        session.commit()
+        channel_id = channel.id
+        template_id = template.id
+
+    client = app_module.app.test_client()
+    with client:
+        login_response = client.post(
+            "/login",
+            data={"username": "admin", "password": "admin"},
+            follow_redirects=True,
+        )
+        assert login_response.status_code == 200
+
+        payload = {
+            "channel_id": str(channel_id),
+            "template_id": str(template_id),
+            "title": "Video",
+            "categoryId": "22",
+            "template_context": json.dumps({"extra": "World", "tags": ["one", "two"]}),
+        }
+        payload["video"] = (io.BytesIO(b"content"), "video.mp4")
+        response = client.post(
+            "/upload",
+            data=payload,
+            content_type="multipart/form-data",
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+    with SessionLocal() as session:
+        job = session.query(Job).one()
+        context = job.template_context
+
+    # Контекст должен быть сериализуемым JSON
+    json.dumps(context)
+    assert context["greeting"] == "Hello"
+    assert context["extra"] == "World"
+    assert context["tags"] == ["one", "two"]
+    assert isinstance(context["links"], dict)
+    assert context["links"]["promo"]["url"] == "https://example.com"
+    assert context["links"]["promo"]["utm"] == {"source": "test"}
+    assert "utm" not in context  # функция не должна попадать в JSON


### PR DESCRIPTION
## Summary
- add a JSON-safe copy of the template rendering context and expose it in render results
- persist only the serializable context in job creation paths, including the API
- cover the upload flow with a regression test that checks the stored context is valid JSON

## Testing
- pytest *(fails: dependency Flask/SQLAlchemy not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a5c0a534833384df80ea6e040c1c